### PR TITLE
Experimental: do not annotate output shapes

### DIFF
--- a/src/exporters/coreml/convert.py
+++ b/src/exporters/coreml/convert.py
@@ -573,27 +573,11 @@ def export_pytorch(
         spec.description.predictedFeatureName = output_desc.name
         mlmodel.output_description[output_desc.name] = output_desc.description
     else:
-        flexible_outputs = config.get_flexible_outputs()
-
         for i, (key, output_desc) in enumerate(output_descs.items()):
             if i < len(example_output):
                 output = spec.description.output[i]
                 ct.utils.rename_feature(spec, output.name, output_desc.name, rename_inputs=False)
                 mlmodel.output_description[output_desc.name] = output_desc.description
-                set_multiarray_shape(output, example_output[i].shape)
-
-                # Set flexible output shape if necessary.
-                if key in flexible_outputs:
-                    lower_bounds = list(example_output[i].shape)
-                    upper_bounds = list(example_output[i].shape)
-
-                    for flexible_output in flexible_outputs[key]:
-                        lower_bounds[flexible_output["axis"]] = flexible_output["min"]
-                        upper_bounds[flexible_output["axis"]] = flexible_output["max"]
-
-                    flexible_shape_utils.set_multiarray_ndshape_range(
-                        spec, output_desc.name, lower_bounds, upper_bounds
-                    )
 
         if config.task in ["object-detection", "semantic-segmentation", "token-classification"]:
             labels = get_labels_as_list(model)


### PR DESCRIPTION
If I'm reading [this comment right](https://github.com/apple/coremltools/issues/1806#issuecomment-1478944212), it looks like annotating flexible output shapes is going to be very hard to support for `ML Program` conversions. Furthermore, annotating _non-flexible_ output shapes still doesn't work in the presence of flexible input shapes, as the conversion carries symbolic information about the shapes through the network. Letting output shapes float seems to work, at least for bert: https://huggingface.co/pcuenq/gists/blob/main/flexible_inputs_only.ipynb.

I'm not sure about the impact of this change. If we decide to go this way, we might want to keep `get_flexible_outputs()` for information and testing purposes. We could create a test (if it doesn't already exist, I didn't check) that runs different sequence lengths and ensures output lengths are consistent with inputs.