### PR TITLE
Fixes to adapt to changes in `transformers`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     include_package_data=True,
     python_requires=">=3.6.0",
     install_requires=[
-        "transformers >= 4.19",
+        "transformers >= 4.26.1",
         "coremltools >= 5.0",
     ],
     classifiers=[

--- a/src/exporters/coreml/config.py
+++ b/src/exporters/coreml/config.py
@@ -750,10 +750,11 @@ class CoreMLConfig():
         else:
             image_size = preprocessor.size
 
-        if isinstance(image_size, tuple):
-            image_width, image_height = image_size
+        if "shortest_edge" in image_size:
+            image_height = image_width = image_size["shortest_edge"]
         else:
-            image_width = image_height = image_size
+            image_height = image_size["height"]
+            image_width = image_size["width"]
 
         pixel_values = np.random.randint(0, 256, (image_width, image_height, 3), dtype=np.uint8)
         coreml_value = Image.fromarray(pixel_values)

--- a/src/exporters/coreml/config.py
+++ b/src/exporters/coreml/config.py
@@ -29,7 +29,7 @@ from ..utils import logging
 
 if TYPE_CHECKING:
     from transformers.configuration_utils import PretrainedConfig
-    from transformers.feature_extraction_utils import FeatureExtractionMixin
+    from transformers.image_processing_utils import ImageProcessingMixin
     from transformers.tokenization_utils_base import PreTrainedTokenizerBase
     from transformers.processing_utils import ProcessorMixin
 
@@ -742,7 +742,7 @@ class CoreMLConfig():
 
     def _generate_dummy_image(
         self,
-        preprocessor: "FeatureExtractionMixin",
+        preprocessor: "ImageProcessingMixin",
         framework: Optional[TensorType] = None,
     ) -> Tuple[Any, Any]:
         if hasattr(preprocessor, "crop_size") and preprocessor.do_center_crop:
@@ -800,14 +800,14 @@ class CoreMLConfig():
 
     def generate_dummy_inputs(
         self,
-        preprocessor: Union["PreTrainedTokenizerBase", "FeatureExtractionMixin", "ProcessorMixin"],
+        preprocessor: Union["PreTrainedTokenizerBase", "ImageProcessingMixin", "ProcessorMixin"],
         framework: Optional[TensorType] = None,
     ) -> Mapping[str, Tuple[Any, Any]]:
         """
         Generate dummy input data to provide to the Core ML exporter.
 
         Args:
-            preprocessor: ([`PreTrainedTokenizerBase`] or [`FeatureExtractionMixin`] or [`ProcessorMixin`]):
+            preprocessor: ([`PreTrainedTokenizerBase`] or [`ImageProcessingMixin`] or [`ProcessorMixin`]):
                 The preprocessor associated with this model configuration.
             framework (`TensorType`, *optional*, defaults to `None`):
                 The framework (PyTorch or TensorFlow) that the preprocessor will generate tensors for.
@@ -816,7 +816,7 @@ class CoreMLConfig():
             `Mapping[str, Tuple[Any, Any]]` holding tuples containing the reference and
             Core ML tensors to provide to the model's forward function.
         """
-        from transformers.feature_extraction_utils import FeatureExtractionMixin
+        from transformers.image_processing_utils import ImageProcessingMixin
         from transformers.tokenization_utils_base import PreTrainedTokenizerBase
         from transformers.processing_utils import ProcessorMixin
 
@@ -867,7 +867,7 @@ class CoreMLConfig():
 
         elif (
             self.modality == "vision"
-            and isinstance(preprocessor, FeatureExtractionMixin)
+            and isinstance(preprocessor, ImageProcessingMixin)
             and preprocessor.model_input_names[0] == "pixel_values"
         ):
             dummy_inputs["pixel_values"] = self._generate_dummy_image(preprocessor, framework)


### PR DESCRIPTION
* `ImageProcessingMixin` was segregated from `FeatureExtractionMixin`, see https://github.com/huggingface/transformers/pull/20501. `FeatureExtractionMixin` already exists, but the appropriate type returned by `AutoProcessor` is now `ImageProcessingMixin`.

* Image sizes were standardized to dicts to avoid ambiguity.

These changes make most of the slow tests (but not all) pass again. Taking a look at the remaining ones.