### PR TITLE
[wip] Attempt to add EfficientNet

### DIFF
--- a/src/exporters/coreml/features.py
+++ b/src/exporters/coreml/features.py
@@ -210,6 +210,11 @@ class FeaturesManager:
             "token-classification",
             coreml_config_cls="models.distilbert.DistilBertCoreMLConfig",
         ),
+        "efficientnet": supported_features_mapping(
+            "default",
+            "image-classification",
+            coreml_config_cls="models.efficientnet.EfficientNetCoreMLConfig",
+        ),
         "ernie": supported_features_mapping(
             "causal-lm",
             "causal-lm-with-past",

--- a/src/exporters/coreml/models.py
+++ b/src/exporters/coreml/models.py
@@ -178,6 +178,32 @@ class DistilBertCoreMLConfig(CoreMLConfig):
             return super().inputs
 
 
+class EfficientNetCoreMLConfig(CoreMLConfig):
+    modality = "vision"
+
+    @property
+    def outputs(self) -> OrderedDict[str, OutputDescription]:
+        if self.task in ["image-classification"]:
+            return OrderedDict(
+                [
+                    (
+                        "logits",
+                        OutputDescription(
+                            "probabilities",
+                            "Probability of each category",
+                            do_softmax=False,
+                        )
+                    ),
+                ]
+            )
+        else:
+            return super().outputs()
+    
+    @property
+    def atol_for_validation(self) -> float:
+        return 1e-3
+
+
 class ErnieCoreMLConfig(CoreMLConfig):
     modality = "text"
 

--- a/tests/test_coreml.py
+++ b/tests/test_coreml.py
@@ -77,6 +77,7 @@ PYTORCH_EXPORT_MODELS = {
     ("squeezebert", "squeezebert/squeezebert-uncased"),
     ("vit", "google/vit-base-patch16-224"),
     ("yolos", "hustvl/yolos-tiny"),
+    ("efficientnet", "google/efficientnet-b1"),
 }
 
 PYTORCH_EXPORT_WITH_PAST_MODELS = {


### PR DESCRIPTION
Note: requires Transfomers 4.27.3.

For some reason, the `default` task works but `image-classification` causes a segmentation fault. The only difference is in the classification head, which already includes a softmax operation. Therefore, I disabled it from the configuration. Keeping the softmax or using `legacy_format` don't work either.