### PR TITLE
Special cases to support T5

### DIFF
--- a/src/exporters/coreml/config.py
+++ b/src/exporters/coreml/config.py
@@ -866,6 +866,15 @@ class CoreMLConfig():
                 encoder_attention_mask = np.ones((batch_size, encoder_sequence_length), dtype=np.int64)
                 dummy_inputs["attention_mask"] = (encoder_attention_mask, encoder_attention_mask.astype(np.int32))
 
+            if self.task == "default" and "decoder_input_ids" in input_descs:
+                # Special case for T5-like models
+                decoder_shape = (batch_size, sequence_length-5)
+                decoder_input_ids = np.random.randint(0, preprocessor.vocab_size, decoder_shape)
+                dummy_inputs["decoder_input_ids"] = (decoder_input_ids, decoder_input_ids.astype(np.int32))
+
+                decoder_attention_mask = np.ones(decoder_shape, dtype=np.int64)
+                dummy_inputs["decoder_attention_mask"] = (decoder_attention_mask, decoder_attention_mask.astype(np.int32))
+
         elif (
             self.modality == "vision"
             and isinstance(preprocessor, ImageProcessingMixin)

--- a/src/exporters/coreml/models.py
+++ b/src/exporters/coreml/models.py
@@ -320,6 +320,44 @@ class SqueezeBertCoreMLConfig(CoreMLConfig):
 
 class T5CoreMLConfig(CoreMLConfig):
     modality = "text"
+    
+    @property
+    def _input_descriptions(self) -> OrderedDict[str, InputDescription]:
+        if self.task == "default":
+            return OrderedDict(
+                [
+                    (
+                        "input_ids",
+                        InputDescription(
+                            "input_ids",
+                            "Indices of input sequence tokens in the vocabulary",
+                            sequence_length=(1, 128),
+                        )
+                    ),
+                    (
+                        "attention_mask",
+                        InputDescription(
+                            "attention_mask",
+                            "Mask to avoid performing attention on padding token indices (1 = not masked, 0 = masked)",
+                        )
+                    ),
+                    (
+                        "decoder_input_ids",
+                        InputDescription(
+                            "decoder_input_ids",
+                            "Indices of decoder input sequence tokens in the vocabulary",
+                        )
+                    ),
+                    (
+                        "decoder_attention_mask",
+                        InputDescription(
+                            "decoder_attention_mask",
+                            "Mask to avoid performing attention on padding token indices (1 = not masked, 0 = masked)",
+                        )
+                    ),
+                ]
+            )
+        return super()._input_descriptions
 
 
 class ViTCoreMLConfig(CoreMLConfig):


### PR DESCRIPTION
T5, as returned by `AutoModel`, requires both `encoder_ids` and `decoder_input_ids`. See for example this ONNX configuration: https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/configuration_t5.py#L143

This patch allows the `default` task of T5 to be converted (`seq2seq-lm` already worked).

An alternative would have been to introduce a new `seq2seq = "encoder/decoder"` property that would be set in `__main__.py` when calling `convert_model`.

The same tests pass in `main` as in this branch.

@hollance do you have any thoughts or additional insight?

