### PR TITLE
Run validation on CPU

### DIFF
--- a/src/exporters/coreml/__main__.py
+++ b/src/exporters/coreml/__main__.py
@@ -19,6 +19,7 @@ from argparse import ArgumentParser
 from pathlib import Path
 
 from coremltools import ComputeUnit
+from coremltools.models import MLModel
 from coremltools.models.utils import _is_macos, _macos_version
 
 from transformers.models.auto import AutoFeatureExtractor, AutoProcessor, AutoTokenizer
@@ -64,6 +65,8 @@ def convert_model(preprocessor, model, model_coreml_config, args, use_past=False
     if not _is_macos() or _macos_version() < (12, 0):
         logger.info("Skipping model validation, requires macOS 12.0 or later")
     else:
+        # Run validation on CPU
+        mlmodel = MLModel(filename, compute_units=ComputeUnit.CPU_ONLY)
         validate_model_outputs(coreml_config, preprocessor, model, mlmodel, args.atol)
 
     logger.info(f"All good, model saved at: {filename}")


### PR DESCRIPTION
This might not be necessary or desirable, but:
- It solves a problem I'm having with the converter Space (details below).
- The reference model is run on CPU to establish the baseline against which results are compared. It could make sense to do the same for the converted model.

### The converter Space problem

Norod78 reported [this issue](https://huggingface.co/spaces/huggingface-projects/transformers-to-coreml/discussions/9#64402bd0d4229e14ae9b2699) on the validation step of a `gpt_neo` model conversion. It consistently happens on the Space hardware (a M1 mini running macOS 12.4), but I couldn't reproduce it on my M1 MBP running 13.3, or on virtualized 12.6 and 12.4 environments running in the same MBP. As far as I can tell the Python virtual environments used in the Space and the test environments are sufficiently close (same torch, coremltools, transformers, accelerate and safetensors versions).

~~My gut suspects the integrated GPU in the mini being the root cause of the problem. However,~~ if you select "CPU" when doing the conversion the same error happens. But doing inference on CPU makes validation succeed.

If this PR is not merged, a model converted in my Mac (which validates correctly), will still cause the same differences in the Space hardware. A model converted in the Space (which fails to validate) works fine on my Mac. The same thing happens if the PR is merged.

### Alternatives I considered.

Validation fails because we are using `allclose` to test. Some data points are indeed not close (delta is ~0.9), but most of the points _are_ close. Apple seems to favor a SNR-based metric, so maybe we could use that instead.

@hollance any other ideas or suggestions?