### PR TITLE
Workaround for `torch.full` to get rank-0 tensor

### DIFF
--- a/src/exporters/coreml/models.py
+++ b/src/exporters/coreml/models.py
@@ -219,9 +219,8 @@ class GPT2CoreMLConfig(CoreMLConfig):
 
             shape = context[node.inputs[0]]
             value = context[node.inputs[1]]
-            print(f"shape: {shape}, value: {value}, name: {node.name}")
 
-            # Shortcut for rank-0 tensor. Setting shape to a var with [] would also work
+            # Shortcut for rank-0 tensor. Setting shape to a Var with [] would also work
             if shape.rank == 1 and shape.shape[0] == 0 and types.is_float(shape.dtype):
                 context.add(value, node.name)
             else:

--- a/src/exporters/coreml/models.py
+++ b/src/exporters/coreml/models.py
@@ -208,10 +208,6 @@ class GPT2CoreMLConfig(CoreMLConfig):
         input_descs["input_ids"].sequence_length = 128
         return input_descs
 
-    @property
-    def use_legacy_format(self) -> bool:
-        return True
-
     def patch_pytorch_ops(self):
         def _fill(context, node):
             from coremltools.converters.mil import Builder as mb

--- a/tests/test_coreml.py
+++ b/tests/test_coreml.py
@@ -70,6 +70,7 @@ PYTORCH_EXPORT_MODELS = {
     ("convnext", "facebook/convnext-tiny-224"),
     ("cvt", "microsoft/cvt-21-384-22k"),
     ("distilbert", "distilbert-base-cased"),
+    ("gpt2", "distilgpt2"),
     ("levit", "facebook/levit-128S"),
     ("mobilebert", "google/mobilebert-uncased"),
     ("mobilevit", "apple/mobilevit-small"),


### PR DESCRIPTION
Restores conversion of GPT-2 until the issue is resolved in coremltools. See [this PR](https://github.com/apple/coremltools/pull/1845) for details.