### PR TITLE
Allow max sequence length to follow the config

### DIFF
--- a/src/exporters/coreml/config.py
+++ b/src/exporters/coreml/config.py
@@ -181,6 +181,18 @@ class CoreMLConfig():
         return common_inputs
 
     @property
+    def inferSequenceLengthFromConfig(self) -> bool:
+        return False
+
+    @property
+    def maxSequenceLength(self) -> int:
+        if self.inferSequenceLengthFromConfig:
+            # Alternatives such as `n_positions` are automatically mapped to `max_position_embeddings`
+            if hasattr(self._config, "max_position_embeddings"):
+                return self._config.max_position_embeddings
+        return 128
+
+    @property
     def _input_descriptions(self) -> "OrderedDict[str, InputDescription]":
         if self.modality in ["text", "audio"] and self.seq2seq == "decoder":
             return OrderedDict(
@@ -232,7 +244,7 @@ class CoreMLConfig():
                         InputDescription(
                             "input_ids",
                             "Indices of input sequence tokens in the vocabulary",
-                            sequence_length=(1, 128),
+                            sequence_length=(1, self.maxSequenceLength),
                         )
                     ),
                     (
@@ -256,7 +268,7 @@ class CoreMLConfig():
                         InputDescription(
                             "input_ids",
                             "Indices of input sequence tokens in the vocabulary",
-                            sequence_length=(1, 128),
+                            sequence_length=(1, self.maxSequenceLength),
                         )
                     ),
                     (

--- a/tests/test_coreml.py
+++ b/tests/test_coreml.py
@@ -57,7 +57,7 @@ class CoreMLConfigTestCase(TestCase):
         self.assertEqual(len(flexible_output), 1)
         self.assertEqual(flexible_output[0]["axis"], 1)
         self.assertEqual(flexible_output[0]["min"], 1)
-        self.assertEqual(flexible_output[0]["max"], 128)
+        self.assertEqual(flexible_output[0]["max"], config.maxSequenceLength)
 
         config = TextCoreMLConfig(None, task="text-classification")
         flexible_outputs = config.get_flexible_outputs()


### PR DESCRIPTION
This requires custom configurations, as the default still uses 128.
Not fully sure this is a great idea, I need to test memory consumption in more depth.

The rationale for this change is that I'm following the steps that would be required to create a modern LM chat UI using Core ML, and see how far we can get.