### PR TITLE
Use fixed input shapes for GPTNeoX

### DIFF
--- a/src/exporters/coreml/models.py
+++ b/src/exporters/coreml/models.py
@@ -263,6 +263,13 @@ class GPTNeoCoreMLConfig(CoreMLConfig):
 class GPTNeoXCoreMLConfig(CoreMLConfig):
     modality = "text"
 
+    @property
+    def inputs(self) -> OrderedDict[str, InputDescription]:
+        input_descs = super().inputs
+        # Flexible shapes are incompatible with gather (https://github.com/huggingface/exporters/issues/43)
+        input_descs["input_ids"].sequence_length = 128
+        return input_descs
+
 
 class LevitCoreMLConfig(CoreMLConfig):
     modality = "vision"


### PR DESCRIPTION
Workaround for #43. Makes `GPTNeoX` compatible with transformers >= 4.28.0.