### PR TITLE
Upgrade to coremltools 7.0b1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,10 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     include_package_data=True,
-    python_requires=">=3.6.0",
+    python_requires=">=3.8.0",
     install_requires=[
-        "transformers >= 4.26.1",
-        "coremltools >= 5.0",
+        "transformers >= 4.29.2",
+        "coremltools >= 7.0b1",
     ],
     classifiers=[
     ],

--- a/src/exporters/coreml/models.py
+++ b/src/exporters/coreml/models.py
@@ -201,23 +201,6 @@ class ErnieCoreMLConfig(CoreMLConfig):
 class GPT2CoreMLConfig(CoreMLConfig):
     modality = "text"
 
-    def patch_pytorch_ops(self):
-        def _fill(context, node):
-            from coremltools.converters.mil import Builder as mb
-            from coremltools.converters.mil.mil import types
-
-            shape = context[node.inputs[0]]
-            value = context[node.inputs[1]]
-
-            # Shortcut for rank-0 tensor. Setting shape to a Var with [] would also work
-            if shape.rank == 1 and shape.shape[0] == 0 and types.is_float(shape.dtype):
-                context.add(value, node.name)
-            else:
-                x = mb.fill(shape=shape, value=value, name=node.name)
-                context.add(x)
-
-        return {"full": _fill}
-
 
 class GPTBigcodeCoreMLConfig(CoreMLConfig):
     modality = "text"


### PR DESCRIPTION
I've been testing `coremltools 7.0b1` for weeks: it's stable, it has a lot of fixes and new features (for quantization, in particular).

I removed a custom torch op workaround for GPT2. Additional workarounds can be removed when a new release of `coremltools` comes out.

I also upgraded the minimum versions of transformers and Python (since Python 3.8 is the minimum required in `transformers`).