### PR TITLE
[CoreML] Use Float16 as the default compute precision

### DIFF
--- a/src/exporters/coreml/__main__.py
+++ b/src/exporters/coreml/__main__.py
@@ -93,7 +93,7 @@ def main():
         "--framework", type=str, choices=["pt", "tf"], default="pt", help="The framework to use for the Core ML export."
     )
     parser.add_argument(
-        "--quantize", type=str, choices=["float32", "float16"], default="float32", help="Quantization option for the model weights."
+        "--quantize", type=str, choices=["float32", "float16"], default="float16", help="Quantization option for the model weights."
     )
     parser.add_argument(
         "--compute_units", type=str, choices=["all", "cpu_and_gpu", "cpu_only", "cpu_and_ne"], default="all", help="Optimize the model for CPU, GPU, and/or Neural Engine."


### PR DESCRIPTION
This PR changes the default compute precision to Float16 (previously: Float32). This stores the weights and does the computation in Float16 when the MLProgram (default) conversion mode is used. This halves the model weights by 2 generally improve the performance without decreasing the accuracy.

As of CoreMLTools 7, the default (and recommended) compute precision when exporting to MLProgram is Float16 so this new default better aligns with the documentation. The regular Float32 precision is still available if the accuracy is not high enough.

I personally never observed a significant drop in performance when exporting vision models to CoreML in Float16 (Yolov8, UNets, etc.). I wasn't able to run the tests because of dependency issues but this would be great to know if a network suffers from poor performance in Float16, especially LLMs.

Note for future improvements of this API:

* I think that the `--quantize` option has a misleading name since it toggles the compute precision, not the quantization. Quantization has another meaning in the CoreMLTools framework. It refers to a weights compression technique (also applies to the activations since CoreMLTools 7 in some circumstances). Maybe another name such as `--precision` would be great.

See issue #56 for context.