### PR TITLE
Add CoreML export support for MobileViTV2 models

### DIFF
--- a/MODELS.md
+++ b/MODELS.md
@@ -236,6 +236,12 @@ Does not work with flexible sequence length and therefore does not support `use_
 - ✅ MobileViTForImageClassification
 - ✅ MobileViTForSemanticSegmentation
 
+**MobileViTv2**
+
+- ✅ MobileViTV2Model
+- ✅ MobileViTV2ForImageClassification
+- ✅ MobileViTV2ForSemanticSegmentation
+
 **SegFormer**
 
 - ✅ SegformerModel

--- a/src/exporters/coreml/features.py
+++ b/src/exporters/coreml/features.py
@@ -307,6 +307,12 @@ class FeaturesManager:
             "semantic-segmentation",
             coreml_config_cls="models.mobilevit.MobileViTCoreMLConfig",
         ),
+        "mobilevitv2": supported_features_mapping(
+            "feature-extraction",
+            "image-classification",
+            "semantic-segmentation",
+            coreml_config_cls="models.mobilevit.MobileViTCoreMLConfig",
+        ),
         "mvp": supported_features_mapping(
             "feature-extraction",
             "text2text-generation",

--- a/tests/test_coreml.py
+++ b/tests/test_coreml.py
@@ -74,6 +74,7 @@ PYTORCH_EXPORT_MODELS = {
     ("levit", "facebook/levit-128S"),
     ("mobilebert", "google/mobilebert-uncased"),
     ("mobilevit", "apple/mobilevit-small"),
+    ("mobilevitv2", "apple/mobilevitv2-1.0-imagenet1k-256"),
     ("segformer", "nvidia/mit-b0"),
     ("squeezebert", "squeezebert/squeezebert-uncased"),
     ("t5", "t5-small"),


### PR DESCRIPTION
The MobileViTV2 models share an image processor with MobileViT and don't need any additional support to export successfully.

Here's an example of converting the `apple/mobilevitv2-1.0-imagenet1k-256 ` model.

(Note that I had to use float32 to pass the numeric validation check, but the float16-quantized model is within ~1e-3 of the actual value and should work fine if you skip the check.)

```
% python -m exporters.coreml --model=apple/mobilevitv2-1.0-imagenet1k-256 --feature image-classification --quantize float32 exported/

Using framework PyTorch: 2.1.0
Converting PyTorch Frontend ==> MIL Ops: 100%|
[...]
Validating Core ML model...
	- Core ML model is classifier, validating output
		-[✓] predicted class 'kite' matches 'kite'
		-[✓] number of classes 1000 matches 1000
		-[✓] all values close (atol: 0.0001)
All good, model saved at: exported/Model.mlpackage
```