### PR TITLE
Fix generate dummy image

### DIFF
--- a/src/exporters/coreml/config.py
+++ b/src/exporters/coreml/config.py
@@ -796,7 +796,7 @@ class CoreMLConfig():
             image_height = image_size["height"]
             image_width = image_size["width"]
 
-        pixel_values = np.random.randint(0, 256, (image_width, image_height, 3), dtype=np.uint8)
+        pixel_values = np.random.randint(0, 256, (image_height, image_width, 3), dtype=np.uint8)
         coreml_value = Image.fromarray(pixel_values)
 
         # Hacky workaround: the Core ML input is the full-sized image, and so


### PR DESCRIPTION
Hello! First and foremost, I want to express my gratitude for your incredible work, which has made it easier than ever to use 🤗 Transformers locally on devices. While exploring various transformers and the tasks they can perform, I noticed a discrepancy in the object detection results compared to Python inference. The issue stemmed from the fact that `CoreMLConfig.generate_dummy_image` generates images with dimensions that do not match the specified ones.

```
image_width, image_height = 512, 288
pixel_values = np.random.randint(0, 256, (image_width, image_height, 3), dtype=np.uint8)
coreml_value = Image.fromarray(pixel_values)
print(f'W:{coreml_value.width}, H:{coreml_value.height}') # W:288, H:512
```
