### PR TITLE
[WIP] Added support for converting LayoutLMv3 to CoreML

### DIFF
--- a/src/exporters/coreml/features.py
+++ b/src/exporters/coreml/features.py
@@ -278,6 +278,10 @@ class FeaturesManager:
             "text-classification",
             coreml_config_cls="models.gpt_neox.GPTNeoXCoreMLConfig",
         ),
+        "layoutlmv3": supported_features_mapping(
+            "token-classification",
+            coreml_config_cls="models.layoutlmv3.LayoutLMv3CoreMLConfig",
+        ),
         "levit": supported_features_mapping(
             "feature-extraction", "image-classification", coreml_config_cls="models.levit.LevitCoreMLConfig"
         ),


### PR DESCRIPTION
This is a WIP implementation of converting a multimodal model (LayoutLMv3) to CoreML. While I was able to adapt the library to convert the model, the resulting model doesn't predict correctly (testing in both Swift on mobile as well as with `coremltools` in Python). I would appreciate any feedback to make it work.

I had to patch two `pytorch` ops:
1. `clip`: As it's an alias of `clamp`, I reused the same code from `coremltools` here.
1. `one_hot`: I used some help from Copilot and LLMs to write this and make it work. However, I am not sure if it's the correct implementation. I suspect that the error might lie in this one.