### PR TITLE
Skip loading of the model during conversion to save on RAM usage

### DIFF
--- a/src/exporters/coreml/convert.py
+++ b/src/exporters/coreml/convert.py
@@ -556,6 +556,7 @@ def export_pytorch(
         convert_to="neuralnetwork" if config.use_legacy_format else "mlprogram",
         compute_units=compute_units,
         **convert_kwargs,
+        skip_model_load=True
     )
 
     if restore_ops is not None:


### PR DESCRIPTION
Helps address #69 somewhat, by preventing coremltools loading the converted model/compiling it post-conversion.

I don't believe exporters is doing anything with either the compiled nor the loaded model (other than just using the spec), so it is probably fine to default to skipping loading the model. I've also seen a recent example this month publishes in swift-transformers that also skipped this step: [sample code here](https://github.com/huggingface/swift-transformers/tree/preview/Examples/Mistral7Brl).

However if desired, I also considered adding in a new argument that would allow users to set this themselves if we don't want to force this default behavior onto people.

I can also add a new section to the troubleshooting section specific to this error if that would be helpful.

Test setup:

M3 Max Macbook Pro with 36GB of RAM
Converting model: Undi95/MythoMax-L2-Kimiko-v2-13b (~26GB model)

**Current behavior w/o this fix:**
Getting a `zsh: killed     python3 -m exporters.coreml ...` error due to running out of memory (see issue for more details).

**Behavior with this fix:**
Able to successfully convert the provided model and similar ones of its size (although much larger than my system's RAM will still not work). This will at least make this tool more accessible for models that should fix inside your RAM size.